### PR TITLE
feat: add Button and DropDown components into ui kit

### DIFF
--- a/packages/shared/src/shared/ui/button/button-type.ts
+++ b/packages/shared/src/shared/ui/button/button-type.ts
@@ -1,0 +1,15 @@
+import { PropsWithChildren, ReactNode } from "react";
+import { ClassNameType } from "../../types/react";
+
+export interface ButtonProps extends PropsWithChildren, ClassNameType {
+    variant?: "text" | "contained" | "outlined";
+    size?: "small" | "medium" | "large";
+    type?: "button" | "submit" | "reset";
+    disabled?: boolean;
+    onClick?: () => void;
+    fullWidth?: boolean;
+    startIcon?: ReactNode;
+    endIcon?: ReactNode;
+    loading?: boolean;
+    loadingText?: string;
+}

--- a/packages/shared/src/shared/ui/button/button.tsx
+++ b/packages/shared/src/shared/ui/button/button.tsx
@@ -1,0 +1,50 @@
+import { FC } from "react";
+import { ButtonProps } from "./button-type.ts";
+import styles from "./styles/button.module.scss";
+
+// <Button
+//   variant="outlined"
+//   size="large"
+//   fullWidth
+//   startIcon={<img src="" />}
+//   loading={true}
+//   loadingText="Загружаем..."
+// >
+//   Отправить
+// </Button>
+
+export const Button: FC<ButtonProps> = ({
+                                            variant = "contained",
+                                            size = "medium",
+                                            type = "button",
+                                            className = "",
+                                            disabled = false,
+                                            onClick,
+                                            fullWidth = false,
+                                            startIcon,
+                                            endIcon,
+                                            loading = false,
+                                            loadingText,
+                                            children
+                                        }) => {
+    const classes = [
+        styles.btn,
+        styles[variant],
+        styles[size],
+        fullWidth ? styles.fullWidth : "",
+        className
+    ].join(" ").trim();
+
+    return (
+        <button
+            type={type}
+            className={classes}
+            disabled={disabled || loading}
+            onClick={onClick}
+        >
+            {startIcon && !loading && <span className={styles.icon}>{startIcon}</span>}
+            {loading ? (loadingText || "Loading...") : children}
+            {endIcon && !loading && <span className={styles.icon}>{endIcon}</span>}
+        </button>
+    );
+};

--- a/packages/shared/src/shared/ui/button/index.ts
+++ b/packages/shared/src/shared/ui/button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from "./button"

--- a/packages/shared/src/shared/ui/button/styles/button.module.scss
+++ b/packages/shared/src/shared/ui/button/styles/button.module.scss
@@ -1,0 +1,105 @@
+$primary-color: #1976d2;
+$primary-dark: #1565c0;
+$primary-darker: #0d47a1;
+$white: #fff;
+$transparent: transparent;
+
+$primary-opacity-light: rgba(25, 118, 210, 0.08);
+$primary-opacity-dark: rgba(25, 118, 210, 0.16);
+$disabled-bg: #e0e0e0;
+$disabled-text: #9e9e9e;
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 6px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    line-height: 1;
+    gap: 8px;
+
+    &:disabled {
+        background-color: $disabled-bg;
+        color: $disabled-text;
+        cursor: not-allowed;
+    }
+}
+
+.contained {
+    background-color: $primary-color;
+    color: $white;
+
+    &:hover:not(:disabled) {
+        background-color: $primary-dark;
+    }
+
+    &:active:not(:disabled) {
+        background-color: $primary-darker;
+    }
+}
+
+.outlined {
+    background-color: $transparent;
+    color: $primary-color;
+    border: 2px solid $primary-color;
+
+    &:hover:not(:disabled) {
+        background-color: $primary-opacity-light;
+    }
+
+    &:active:not(:disabled) {
+        background-color: $primary-opacity-dark;
+    }
+}
+
+.text {
+    background-color: $transparent;
+    color: $primary-color;
+    border: none;
+
+    &:hover:not(:disabled) {
+        background-color: $primary-opacity-light;
+    }
+
+    &:active:not(:disabled) {
+        background-color: $primary-opacity-dark;
+    }
+}
+
+.small {
+    padding: 4px 10px;
+    font-size: 13px;
+}
+
+.medium {
+    padding: 8px 16px;
+    font-size: 15px;
+}
+
+.large {
+    padding: 12px 20px;
+    font-size: 17px;
+}
+
+.fullWidth {
+    width: 100%;
+}
+
+.icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:first-child {
+        margin-right: 4px;
+    }
+
+    &:last-child {
+        margin-left: 4px;
+    }
+}

--- a/packages/shared/src/shared/ui/dropDown/dropdown-type.ts
+++ b/packages/shared/src/shared/ui/dropDown/dropdown-type.ts
@@ -1,0 +1,14 @@
+export interface DropdownOption {
+    label: string;
+    value: string;
+}
+
+export interface DropdownProps {
+    options: DropdownOption[];
+    value: string;
+    onChange: (value: string) => void;
+    className?: string;
+    placeholder?: string;
+    disabled?: boolean;
+    fullWidth?: boolean;
+}

--- a/packages/shared/src/shared/ui/dropDown/dropdown.tsx
+++ b/packages/shared/src/shared/ui/dropDown/dropdown.tsx
@@ -1,0 +1,47 @@
+import { FC } from "react";
+import { DropdownProps } from "./dropdown-type";
+import styles from "./styles/dropdown.module.scss";
+import clsx from "clsx";
+
+// <Dropdown
+//   value={selected}
+//   onChange={setSelected}
+//   options={[
+//     { label: "Один", value: "1" },
+//   ]}
+//   placeholder="123"
+//   fullWidth
+// />
+
+export const Dropdown: FC<DropdownProps> = ({
+                                                options,
+                                                value,
+                                                onChange,
+                                                className = "",
+                                                placeholder = "",
+                                                disabled = false,
+                                                fullWidth = false
+                                            }) => {
+    const classes = clsx(
+        styles.dropdown,
+        fullWidth && styles.fullWidth,
+        disabled && styles.disabled,
+        className
+    );
+
+    return (
+        <select
+            className={classes}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+        >
+            {placeholder && <option value="" disabled hidden>{placeholder}</option>}
+            {options.map((option) => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+    );
+};

--- a/packages/shared/src/shared/ui/dropDown/index.ts
+++ b/packages/shared/src/shared/ui/dropDown/index.ts
@@ -1,0 +1,1 @@
+export { Dropdown } from './dropdown';

--- a/packages/shared/src/shared/ui/dropDown/styles/dropdown.module.scss
+++ b/packages/shared/src/shared/ui/dropDown/styles/dropdown.module.scss
@@ -1,0 +1,49 @@
+@use "sass:color";
+
+$primary-color: #1976d2;
+$primary-dark: #1565c0;
+$primary-darker: #0d47a1;
+$white: #fff;
+$transparent: transparent;
+
+$primary-opacity-light: rgba(25, 118, 210, 0.08);
+$primary-opacity-dark: rgba(25, 118, 210, 0.16);
+$disabled-bg: #e0e0e0;
+$disabled-text: #9e9e9e;
+
+.dropdown {
+    appearance: none;
+    background-color: $white;
+    border: 2px solid $primary-color;
+    color: $primary-color;
+    font-size: 15px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+
+    &:hover {
+        background-color: $primary-opacity-light;
+    }
+
+    &:focus {
+        outline: none;
+        border-color: $primary-dark;
+    }
+
+    option {
+        color: #000;
+    }
+}
+
+.fullWidth {
+    width: 100%;
+}
+
+.disabled {
+    background-color: $disabled-bg;
+    color: $disabled-text;
+    border-color: $disabled-bg;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
В этом пулл-реквесте добавлены новые UI-компоненты для библиотеки ui-kit:

- Компонент Button с поддержкой вариантов оформления и размеров.
- Компонент DropDown с возможностью выбора из списка, поддержкой placeholder и полной ширины.

Компоненты стилизованы с помощью SCSS и готовы к использованию в проекте.

Это позволит унифицировать кнопки и выпадающие списки по всему приложению и упростит разработку интерфейсов.
